### PR TITLE
Changed outpuf file oflags for pifm.c and piam.c 

### DIFF
--- a/am/piam.c
+++ b/am/piam.c
@@ -18,7 +18,7 @@
 #define ln(x) (log(x)/log(2.718281828459045235f))
 #define		BUFFER_LEN	1024*8
 int FileFreqTiming;
-// Test program using SNDFILE 
+// Test program using SNDFILE
 // see http://www.mega-nerd.com/libsndfile/api.html for API
 void WriteTone(double Frequency,uint32_t Timing)
 {
@@ -27,7 +27,7 @@ typedef struct {
 		uint32_t WaitForThisSample;
 	} samplerf_t;
 	samplerf_t RfSample;
-	
+
 
 	RfSample.Frequency=Frequency;
 	RfSample.WaitForThisSample=Timing; //en 100 de nanosecond
@@ -43,17 +43,17 @@ int main(int argc, char **argv) {
 	float data_filtered[2*BUFFER_LEN] ; // we generate complex I/Q samples
 	SNDFILE      *infile, *outfile ;
 	SF_INFO		sfinfo ;
-	
+
     int			readcount, nb_samples ;
     char	*infilename  ;
     char	*outfilename  ;
 	int k   ;
 	float x ;
-	
+
 	if( argc < 2 ) {
 		printf("Usage : %s in.wav [out.wav]\n", argv[0]);
 		return(1);
-	}	
+	}
 	infilename = argv[1] ;
 	if( argc == 3 ) {
 		outfilename = argv[2] ;
@@ -68,31 +68,31 @@ int main(int argc, char **argv) {
         puts (sf_strerror (NULL)) ;
         return  1 ;
     } ;
-	
+
 	if( sfinfo.samplerate != 48000 ) {
 		printf("Input rate must be 48K.\n");
 		return 1 ;
 	}
- 
-	FileFreqTiming = open(outfilename, O_RDONLY);
-    
-		
+
+	FileFreqTiming = open(outfilename, O_RWONLY);
+
+
 	/** **/
 	printf ("Reading file : %s\n", infilename ) ;
 	printf ("Sample Rate : %d\n", sfinfo.samplerate) ;
 	printf ("Channels    : %d\n", sfinfo.channels) ;
 	printf ("----------------------------------------\n") ;
 	printf ("Writing file : %s\n", outfilename ) ;
-	
-	
-	
+
+
+
     /* While there are.frames in the input file, read them, process
     ** them and write them to the output file.
     */
-	
+
     while ((readcount = sf_readf_float(infile, data, BUFFER_LEN)))
-    {   
-		nb_samples = readcount / sfinfo.channels ;		
+    {
+		nb_samples = readcount / sfinfo.channels ;
 		for( k=0 ; k < nb_samples ; k++ ) {
 			x = data[k*sfinfo.channels] ;
 			if( sfinfo.channels == 2 ) {
@@ -107,18 +107,18 @@ int main(int argc, char **argv) {
 						double ampf=x/32767.0;
       						 ampf = (fabs(ampf) < 1.0f/A) ? A*fabs(ampf)/(1.0f+ln(A)) : (1.0f+ln(A*fabs(ampf)))/(1.0f+ln(A)); //compand
 						x= (int)(round(ampf * 32767.0f)) ;
-			*/			
+			*/
 			WriteTone(x*32767*FactAmplitude,1e9/48000.0);
-			 	
+
 		}
-        	
+
     } ;
 
     /* Close input and output files. */
     sf_close (infile) ;
 close(FileFreqTiming);
-   
 
-    
+
+
     return 0;
 }

--- a/fm/pifm.c
+++ b/fm/pifm.c
@@ -18,7 +18,7 @@
 
 #define		BUFFER_LEN	1024*8
 int FileFreqTiming;
-// Test program using SNDFILE 
+// Test program using SNDFILE
 // see http://www.mega-nerd.com/libsndfile/api.html for API
 void WriteTone(double Frequency,uint32_t Timing)
 {
@@ -27,7 +27,7 @@ typedef struct {
 		uint32_t WaitForThisSample;
 	} samplerf_t;
 	samplerf_t RfSample;
-	
+
 
 	RfSample.Frequency=Frequency;
 	RfSample.WaitForThisSample=Timing; //en 100 de nanosecond
@@ -43,17 +43,17 @@ int main(int argc, char **argv) {
 	float data_filtered[2*BUFFER_LEN] ; // we generate complex I/Q samples
 	SNDFILE      *infile, *outfile ;
 	SF_INFO		sfinfo ;
-	
+
     int			readcount, nb_samples ;
     char	*infilename  ;
     char	*outfilename  ;
 	int k   ;
 	float x ;
-	
+
 	if( argc < 2 ) {
 		printf("Usage : %s in.wav [out.wav]\n", argv[0]);
 		return(1);
-	}	
+	}
 	infilename = argv[1] ;
 	if( argc == 3 ) {
 		outfilename = argv[2] ;
@@ -68,31 +68,31 @@ int main(int argc, char **argv) {
         puts (sf_strerror (NULL)) ;
         return  1 ;
     } ;
-	
+
 	if( sfinfo.samplerate != 48000 ) {
 		printf("Input rate must be 48K.\n");
 		return 1 ;
 	}
- 
-	FileFreqTiming = open(outfilename, O_RDONLY);
-    
-		
+
+	FileFreqTiming = open(outfilename, O_RWONLY);
+
+
 	/** **/
 	printf ("Reading file : %s\n", infilename ) ;
 	printf ("Sample Rate : %d\n", sfinfo.samplerate) ;
 	printf ("Channels    : %d\n", sfinfo.channels) ;
 	printf ("----------------------------------------\n") ;
 	printf ("Writing file : %s\n", outfilename ) ;
-	
-	
-	
+
+
+
     /* While there are.frames in the input file, read them, process
     ** them and write them to the output file.
     */
 	int Excursion=6000;
     while ((readcount = sf_readf_float(infile, data, BUFFER_LEN)))
-    {   
-		nb_samples = readcount / sfinfo.channels ;		
+    {
+		nb_samples = readcount / sfinfo.channels ;
 		for( k=0 ; k < nb_samples ; k++ ) {
 			x = data[k*sfinfo.channels] ;
 			if( sfinfo.channels == 2 ) {
@@ -102,16 +102,16 @@ int main(int argc, char **argv) {
 			}
 			//printf("%f \n",x);
 			WriteTone(x*Excursion*2.0,1e9/48000.0);
-			 	
+
 		}
-        	
+
     } ;
 
     /* Close input and output files. */
     sf_close (infile) ;
 close(FileFreqTiming);
-   
 
-    
+
+
     return 0;
 }


### PR DESCRIPTION
I was having an error using pifm. The program repeatedly printed "Unable to write sample" and didn't produce a .ft file. It looks like this was because the output file was opened in read-only mode.