### PR TITLE
Fix broken pifm.c and piam.c (O_RWONLY instead of O_WRONLY)

### DIFF
--- a/am/piam.c
+++ b/am/piam.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 		return 1 ;
 	}
 
-	FileFreqTiming = open(outfilename, O_RWONLY);
+	FileFreqTiming = open(outfilename, O_WRONLY|O_CREAT, 0644);
 
 
 	/** **/

--- a/fm/pifm.c
+++ b/fm/pifm.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 		return 1 ;
 	}
 
-	FileFreqTiming = open(outfilename, O_RWONLY);
+	FileFreqTiming = open(outfilename, O_WRONLY|O_CREAT, 0644);
 
 
 	/** **/


### PR DESCRIPTION
This fixes broken compilation of `pifm.c` and `piam.c` (error introduced with latest commit).

Example:

```
../fm/pifm.c: In function ‘main’:
../fm/pifm.c:77:37: error: ‘O_RWONLY’ undeclared (first use in this function)
  FileFreqTiming = open(outfilename, O_RWONLY);
                                     ^
../fm/pifm.c:77:37: note: each undeclared identifier is reported only once for each function it appears in
../am/piam.c: In function ‘main’:
../am/piam.c:77:37: error: ‘O_RWONLY’ undeclared (first use in this function)
  FileFreqTiming = open(outfilename, O_RWONLY);
                                     ^
../am/piam.c:77:37: note: each undeclared identifier is reported only once for each function it appears in
```