### PR TITLE
Added specific input wave file format

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ sudo ./rpitx -m IQ -i ssbIQ.wav -f 50000 -l
 ```
 A sample script : **testssb.sh** is included.
 <h3> FM modulation </h3>
-**pifm** convert an audio file (Wav 48KHZ mono only!) to Narrow band FM (12.5khz excursion) and output it on a .ft file.
+**pifm** convert an audio file (Wav, 48KHz, 1 channel, pcm_s16le codec) to Narrow band FM (12.5khz excursion) and output it on a .ft file.
 Assuming your audio file is in the folder
 ```
 ./pifm audio48mono.wav fm.ft


### PR DESCRIPTION
As a noob to radio stuff, I had to do a lot of trial and error to figure out the exact format that pifm was expecting. The exact command I had to use was:
ffmpeg -i sample.mp3 -acodec pcm_s16le -ar 48000 -ac 1 sample.wav