### PR TITLE
Fix Python interface and add support for broadcasting any avconv supported media

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,12 @@ setup(
         Extension(
             '_rpitx',
             [
-                'src/python/_rpitxmodule.c',
-                'src/RpiTx.c',
-                'src/mailbox.c',
                 'src/RpiDma.c',
                 'src/RpiGpio.c',
+                'src/RpiTx.c',
+                'src/mailbox.c',
+                'src/python/_rpitxmodule.c',
+                'src/raspberry_pi_revision.c',
             ],
             extra_link_args=['-lrt', '-lsndfile'],
         ),

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,14 @@ setup(
                 'src/mailbox.c',
                 'src/python/_rpitxmodule.c',
                 'src/raspberry_pi_revision.c',
-            ],
+                ],
             extra_link_args=['-lrt', '-lsndfile'],
-        ),
-    ],
+            ),
+        ],
     packages=['rpitx'],
     package_dir={'': 'src/python'},
-    install_requires=['pydub', 'wave'],
-)
+    install_requires=[
+        'ffmpegwrapper==0.1-dev',
+        'pypi-libavwrapper',
+        ],
+    )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, Extension
 
 setup(
     name='rpitx',
-    version='0.1',
+    version='0.2',
     description='Raspyberry Pi radio transmitter',
     author='Brandon Skari',
     author_email='brandon@skari.org',

--- a/src/python/_rpitxmodule.c
+++ b/src/python/_rpitxmodule.c
@@ -153,7 +153,7 @@ _rpitx_broadcast_fm(PyObject* self, PyObject* args) {
 		SIGWINCH,  // Window resized
 		0
 	};
-	pitx_run(MODE_RF, bitRate, frequency * 1000.0, 0.0, 0, formatRfWrapper, reset, skipSignals);
+	pitx_run(MODE_RF, bitRate, frequency * 1000.0, 0.0, 0, formatRfWrapper, reset, skipSignals, 0);
 	sf_close(sndFile);
 
 	Py_RETURN_NONE;

--- a/src/python/_rpitxmodule.c
+++ b/src/python/_rpitxmodule.c
@@ -46,7 +46,7 @@ static ssize_t formatRfWrapper(void* const outBuffer, const size_t count) {
 	samplerf.waitForThisSample = 1e9 / ((float)sampleRate);  //en 100 de nanosecond
 	char* const out = outBuffer;
 
-	while (numBytesWritten < count - sizeof(samplerf_t)) {
+	while (numBytesWritten <= count - sizeof(samplerf_t)) {
 		for (
 				;
 				numBytesWritten <= count - sizeof(samplerf_t) && wavOffset < wavFilled;
@@ -70,7 +70,8 @@ static ssize_t formatRfWrapper(void* const outBuffer, const size_t count) {
 static size_t read_float(int streamFileNo, float* wavBuffer, const size_t count) {
 	// Samples are stored as 16 bit signed integers in range of -32768 to 32767
 	uint16_t sample;
-	for (int i = 0; i < count; ++i) {
+	int i;
+	for (i = 0; i < count; ++i) {
 		const int byteCount = read(streamFileNo, &sample, sizeof(sample));
 		if (byteCount != sizeof(sample)) {
 			return i;

--- a/src/python/rpitx/__init__.py
+++ b/src/python/rpitx/__init__.py
@@ -1,4 +1,4 @@
 """Python interface to rpitx."""
 
 # To avoid import pollution with ipython, hide functions in another module
-from _hidden import broadcast_fm
+from ._hidden import broadcast_fm

--- a/src/python/rpitx/_hidden.py
+++ b/src/python/rpitx/_hidden.py
@@ -8,6 +8,9 @@ import os
 import subprocess
 import threading
 
+PIPE = 'pipe:1'
+DUMMY_FILE = 'dummy-file'
+
 
 def broadcast_fm(media_file_name, frequency):
     """Play a media file's audio over FM."""
@@ -29,36 +32,38 @@ def broadcast_fm(media_file_name, frequency):
         VideoCodec = libavwrapper.VideoCodec
         AudioCodec = libavwrapper.AudioCodec
         Stream = libavwrapper.AVConv
+        Stream.add_option = Stream.add_parameter
         command = 'avconv'
     else:
         raise NotImplementedError(
-            'Broadcasting audio requires either avconv or ffmpeg to be installed'
+            'Broadcasting audio requires either avconv or ffmpeg to be installed\n'
+            'sudo apt install libav-tools'
         )
 
-    logger.debug('Using {}'.format(command))
+    logger.debug('Using %s', command)
 
-    pipe_name = '/tmp/rpitx-fifo.wav'
-    if not os.path.exists(pipe_name):
-        os.mkfifo(pipe_name)
+    input_media = Input(media_file_name)
+    codec = AudioCodec('pcm_s16le').frequence(48000).channels(1)
+    output_audio = Output(DUMMY_FILE, codec)
+    stream = Stream(command, input_media, output_audio)
+    command_line = list(stream)
+    # The format needs to be specified manually because we're writing to
+    # stderr and not a named file. Normally, it would infer the format from
+    # the file name extension. Also, ffmpeg will only write to a pipe if it's
+    # the last named argument.
+    command_line.remove(DUMMY_FILE)
+    command_line += ('-f', 'wav', PIPE)
+    logger.debug('Running command "%s"', ' '.join(command_line))
+    stream_process = subprocess.Popen(command_line, stdout=subprocess.PIPE)
 
-    def convert():
-        """Runs the conversion command and writes to a FIFO."""
-        input_media = Input(media_file_name)
-        codec = AudioCodec('pcm_s16le').frequence(48000).channels(1)
-        output_audio = Output(pipe_name, codec)
-        stream = Stream(command, input_media, output_audio)
-        # Force overwriting existing file (it's a FIFO, that's what we want)
-        if hasattr(stream, 'add_option'):
-            stream.add_option('-y', '')
-        else:
-            stream.add_parameter('-y', '')
-        logger.debug(str(stream).replace("'", '').replace(',', ''))
+    def log_stdout():
+        """Log stdout from the stream process."""
         lines = stream.run()
         for line in lines:
             logger.debug(line)
 
-    thread = threading.Thread(target=convert)
-    thread.start()
+    #thread = threading.Thread(target=log_stdout).start()
+
     logger.debug('Calling broadcast_fm')
-    _rpitx.broadcast_fm(pipe_name, frequency)
+    _rpitx.broadcast_fm(stream_process.stdout.fileno(), frequency)
     thread.join()

--- a/src/python/rpitx/_hidden.py
+++ b/src/python/rpitx/_hidden.py
@@ -1,42 +1,57 @@
 """Hides imports and other irrelevant things so that ipython works nicely."""
 
-from pydub import AudioSegment
 import _rpitx
-import io
-import array
+import ffmpegwrapper
+import libavwrapper
 import logging
-import wave
+import os
+import subprocess
+import threading
 
 
-def broadcast_fm(file_, frequency):
-    """Play a music file over FM."""
+def broadcast_fm(media_file_name, frequency):
+    """Play a media file's audio over FM."""
 
     logging.basicConfig()
     logger = logging.getLogger('rpitx')
 
-    def _reencode(file_name):
-        """Returns an AudioSegment file reencoded to the proper WAV format."""
-        original = AudioSegment.from_file(file_name)
-        if original.channels > 2:
-            raise ValueError('Too many channels in sound file')
-        if original.channels == 2:
-            # TODO: Support stereo. For now, just overlay into mono.
-            logger.info('Reducing stereo channels to mono')
-            left, right = original.split_to_mono()
-            original = left.overlay(right)
+    if subprocess.call(('which', 'ffmpeg')) == 1:
+        Input = ffmpegwrapper.Input
+        Output = ffmpegwrapper.Output
+        VideoCodec = ffmpegwrapper.VideoCodec
+        AudioCoded = ffmpegwrapper.AudioCodec
+        Stream = ffmpegwrapper.FFmpeg
+        command = 'ffmpeg'
+    elif subprocess.call(('which', 'avconv')) == 1:
+        Input = libavwrapper.Input
+        Output = libavwrapper.Output
+        VideoCodec = libavwrapper.VideoCodec
+        AudioCoded = libavwrapper.AudioCodec
+        Stream = libavwrapper.AVConv
+        command = 'avconv'
+    else:
+        raise NotImplementedError(
+            'Broadcasting audio requires either avconv or ffmpeg to be installed'
+        )
 
-        return original
+    logger.debug('Using {}'.format(command))
 
-    raw_audio_data = _reencode(file_)
+    pipe_name = '/tmp/rpitx-fifo.wav'
+    if not os.path.exists(pipe_name):
+        os.mkfifo(pipe_name)
 
-    wav_data = io.BytesIO()
-    wav_writer = wave.open(wav_data, 'w')
-    wav_writer.setnchannels(1)
-    wav_writer.setsampwidth(2)
-    wav_writer.setframerate(48000)
-    wav_writer.writeframes(raw_audio_data.raw_data)
-    wav_writer.close()
+    def convert():
+        """Runs the conversion command and writes to a FIFO."""
+        input_media = Input(media_file_name)
+        codec = AudioCodec('pcm_s16le').frequence(48000).channels(1)
+        output_audio = Output(pipe_name, pipe_out)
+        stream = Stream(command, input_media, output_audio)
+        stream.add_option('-y', '')  # Force overwriting existing file
+        logger.debug('Extracting and converting audio')
+        stream.run()
 
-    raw_array = array.array('b', wav_data.getvalue())
-    array_address, length = raw_array.buffer_info()
-    _rpitx.broadcast_fm(array_address, length, frequency)
+    thread = threading.Thread(target=convert)
+    thread.start()
+    logger.debug('Calling broadcast_fm')
+    _rpitx.broadcast_fm(pipe_name, frequency)
+    thread.join()

--- a/src/python/rpitx/_hidden.py
+++ b/src/python/rpitx/_hidden.py
@@ -1,20 +1,23 @@
 """Hides imports and other irrelevant things so that ipython works nicely."""
 
-import _rpitx
-import ffmpegwrapper
-import libavwrapper
 import logging
 import os
 import subprocess
 import sys
 import threading
+import _rpitx
+import ffmpegwrapper
+import libavwrapper
 
 PIPE = 'pipe:1'
 DUMMY_FILE = 'dummy-file.wav'
 
 
 def broadcast_fm(media_file_name, frequency):
-    """Play a media file's audio over FM."""
+    """Broadcast a media file's audio over FM.
+Args:
+    media_file_name (str): The file to broadcast.
+    frequency (float): The frequency, in MHz, to broadcast on."""
 
     logging.basicConfig()
     logger = logging.getLogger('rpitx')

--- a/src/python/rpitx/_hidden.py
+++ b/src/python/rpitx/_hidden.py
@@ -62,7 +62,7 @@ def broadcast_fm(media_file_name, frequency):
         for line in lines:
             logger.debug(line)
 
-    #thread = threading.Thread(target=log_stdout).start()
+    thread = threading.Thread(target=log_stdout).start()
 
     logger.debug('Calling broadcast_fm')
     _rpitx.broadcast_fm(stream_process.stdout.fileno(), frequency)

--- a/src/python/rpitx/_hidden.py
+++ b/src/python/rpitx/_hidden.py
@@ -1,8 +1,8 @@
 """Hides imports and other irrelevant things so that ipython works nicely."""
 
 from pydub import AudioSegment
-import StringIO
 import _rpitx
+import io
 import array
 import logging
 import wave
@@ -29,7 +29,7 @@ def broadcast_fm(file_, frequency):
 
     raw_audio_data = _reencode(file_)
 
-    wav_data = StringIO.StringIO()
+    wav_data = io.BytesIO()
     wav_writer = wave.open(wav_data, 'w')
     wav_writer.setnchannels(1)
     wav_writer.setsampwidth(2)
@@ -37,6 +37,6 @@ def broadcast_fm(file_, frequency):
     wav_writer.writeframes(raw_audio_data.raw_data)
     wav_writer.close()
 
-    raw_array = array.array('c', wav_data.getvalue())
+    raw_array = array.array('b', wav_data.getvalue())
     array_address, length = raw_array.buffer_info()
     _rpitx.broadcast_fm(array_address, length, frequency)


### PR DESCRIPTION
Description
=========

This branch fixes the Python interface which was recently broken, and adds support for broadcasting any media file with audio supported by avconv or ffmpeg.

You can install and test this by running:
Either globally in the system wide Python interpreter:

    sudo pip install https://github.com/bskari/rpitx/archive/avconv.zip
    sudo python

or in a local virtual environment:

    mkvirtualenv rpitx
    pip install https://github.com/bskari/rpitx/archive/avconv.zip
    sudo $(which python)

Then run

    import rpitx
    import logging
    logging.basicConfig(level=logging.DEBUG)  # Turn on debug logging
    rpitx.broadcast_fm('media.mp4', 99.9)


Bugs and future work
==========

Broadcasting longer files seems to stop after about a minute. Watching the waterfall view in `gqrx` shows that something is definitely changing, but I'm not sure what. However, `rpitx` seems to do the same thing if you manually format the file using `avconv`/`ffmpeg`, run that file through `pifm`, and then broadcast it through rpitx. I need to investigate more to try to fix this.

Some comments in `RpiTx.c` have some TODOs to free some pointers at the end of software. This isn't a big problem when running `rpitx` and then exiting, but it may be a problem when a Python program runs for a long time and calls `broadcast_fm` repeatedly. I need to investigate this more.

I've also started looking in to adding a Python interface to broadcast arbitrary images over SSTV.