### PR TITLE
modify header path to be consistent with librpitx install rule + link to library (and not objects)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,95 +1,95 @@
 all: ../pisstv ../piopera ../pifsq ../pichirp ../sendiq ../tune ../freedv ../pocsag ../spectrumpaint ../pifmrds ../rpitx ../corel8 ../pift8 ../sendook ../morse ../foxhunt ../pirtty
 
-CFLAGS	= -Wall -g -O2 -Wno-unused-variable
-CXXFLAGS = -std=c++11 -Wall -g -O2 -Wno-unused-variable
-LDFLAGS = librpitx/src/librpitx.a -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
-CCP = c++
-CC = cc
+CFLAGS	?= -Wall -g -O2 -Wno-unused-variable
+CXXFLAGS ?= -std=c++11 -Wall -g -O2 -Wno-unused-variable
+LDFLAGS ?= -L/opt/vc/lib
+LDFLAGS += -lrpitx -lm -lrt -lpthread
+CXX ?= c++
+CC ?= cc
 
 CFLAGS_Pissb	= -Wall -g -O2 -Wno-unused-variable
-LDFLAGS_Pissb	= librpitx/src/librpitx.a -lm -lrt -lpthread -lsndfile -lliquid -L/opt/vc/lib -lbcm_host
+LDFLAGS_Pissb	= $(LDFLAGS) -lsndfile -lliquid
 
-../pissb: ssbgen/test_ssb.c ssbgen/ssb_gen.c ssbgen/liquid_ssb.c librpitx/src/librpitx.a
+../pissb: ssbgen/test_ssb.c ssbgen/ssb_gen.c ssbgen/liquid_ssb.c 
 	$(CC) $(CFLAGS_Pissb) -o ../pissb ssbgen/liquid_ssb.c $(LDFLAGS_Pissb)
 
-../pisstv : sstv/pisstv.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../pisstv sstv/pisstv.cpp  $(LDFLAGS)
+../pisstv : sstv/pisstv.cpp 
+	$(CXX) $(CXXFLAGS) -o ../pisstv sstv/pisstv.cpp  $(LDFLAGS)
 	
-../foxhunt : foxhunt/foxhunt.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../foxhunt foxhunt/foxhunt.cpp  $(LDFLAGS)
+../foxhunt : foxhunt/foxhunt.cpp
+	$(CXX) $(CXXFLAGS) -o ../foxhunt foxhunt/foxhunt.cpp  $(LDFLAGS)
 	
 	
-../pirtty : pirtty/pirtty.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../pirtty pirtty/pirtty.cpp  $(LDFLAGS)
+../pirtty : pirtty/pirtty.cpp
+	$(CXX) $(CXXFLAGS) -o ../pirtty pirtty/pirtty.cpp  $(LDFLAGS)
 
-../piopera : opera/opera.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../piopera opera/opera.cpp  $(LDFLAGS)
+../piopera : opera/opera.cpp 
+	$(CXX) $(CXXFLAGS) -o ../piopera opera/opera.cpp  $(LDFLAGS)
 
-../pifsq : fsq/pifsq.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../pifsq fsq/pifsq.cpp  $(LDFLAGS)
+../pifsq : fsq/pifsq.cpp 
+	$(CXX) $(CXXFLAGS) -o ../pifsq fsq/pifsq.cpp  $(LDFLAGS)
 
-../pichirp : chirp/chirp.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../pichirp chirp/chirp.cpp  $(LDFLAGS)
+../pichirp : chirp/chirp.cpp 
+	$(CXX) $(CXXFLAGS) -o ../pichirp chirp/chirp.cpp $(LDFLAGS) 
 
-../morse : morse/morse.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../morse morse/morse.cpp  $(LDFLAGS)
+../morse : morse/morse.cpp 
+	$(CXX) $(CXXFLAGS) -o ../morse morse/morse.cpp  $(LDFLAGS)
 
-../sendiq : sendiq.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../sendiq sendiq.cpp  $(LDFLAGS)
+../sendiq : sendiq.cpp 
+	$(CXX) $(CXXFLAGS) -o ../sendiq sendiq.cpp  $(LDFLAGS)
 
-../tune : tune.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../tune tune.cpp  $(LDFLAGS)
+../tune : tune.cpp 
+	$(CXX) $(CXXFLAGS) -o ../tune tune.cpp  $(LDFLAGS)
 
-../freedv : freedv/freedv.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../freedv freedv/freedv.cpp  $(LDFLAGS)
+../freedv : freedv/freedv.cpp 
+	$(CXX) $(CXXFLAGS) -o ../freedv freedv/freedv.cpp  $(LDFLAGS)
 
-../dvbrf : dvb/dvbrf.cpp dvb/dvbsenco8.s dvb/fec100.c dvb/dvbs2arm_1v30.s librpitx/src/librpitx.a
+../dvbrf : dvb/dvbrf.cpp dvb/dvbsenco8.s dvb/fec100.c dvb/dvbs2arm_1v30.s 
 	$(CC) $(CFLAGS) -c -o dvb/dvbsenco8.o dvb/dvbsenco8.s
 	$(CC) $(CFLAGS) -c -o dvb/dvbs2arm_1v30.o dvb/dvbs2arm_1v30.s
 	$(CC) $(CFLAGS) -c -o dvb/fec100.o dvb/fec100.c
-	$(CCP) $(CXXFLAGS) -o ../dvbrf dvb/dvbrf.cpp dvb/dvbsenco8.o dvb/fec100.o dvb/dvbs2arm_1v30.o $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o ../dvbrf dvb/dvbrf.cpp dvb/dvbsenco8.o dvb/fec100.o dvb/dvbs2arm_1v30.o $(LDFLAGS)
 
-../pocsag: pocsag/pocsag.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../pocsag pocsag/pocsag.cpp $(LDFLAGS)
+../pocsag: pocsag/pocsag.cpp 
+	$(CXX) $(CXXFLAGS) -o ../pocsag pocsag/pocsag.cpp $(LDFLAGS)
 
-../spectrumpaint: spectrumpaint/spectrum.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -o ../spectrumpaint spectrumpaint/spectrum.cpp $(LDFLAGS)
+../spectrumpaint: spectrumpaint/spectrum.cpp 
+	$(CXX) $(CXXFLAGS) -o ../spectrumpaint spectrumpaint/spectrum.cpp $(LDFLAGS)
 
-../pifmrds: pifmrds/rds.c pifmrds/waveforms.c pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.c pifmrds/control_pipe.c librpitx/src/librpitx.a
+../pifmrds: pifmrds/rds.c pifmrds/waveforms.c pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.c pifmrds/control_pipe.c 
 	$(CC) $(CFLAGS) -c -o pifmrds/rds.o pifmrds/rds.c
 	$(CC) $(CFLAGS) -c -o pifmrds/control_pipe.o pifmrds/control_pipe.c
 	$(CC) $(CFLAGS) -c -o pifmrds/waveforms.o pifmrds/waveforms.c
 	$(CC) $(CFLAGS) -c -o pifmrds/rds_wav.o pifmrds/rds_wav.c
 	$(CC) $(CFLAGS) -c -o pifmrds/fm_mpx.o pifmrds/fm_mpx.c
 	$(CC) -o pifmrds/rds_wav pifmrds/rds_wav.o pifmrds/rds.o pifmrds/waveforms.o pifmrds/fm_mpx.o -lm -lsndfile
-	$(CCP) $(CXXFLAGS) -Wno-write-strings -o ../pifmrds pifmrds/rds.o pifmrds/waveforms.o pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.o pifmrds/control_pipe.o librpitx/src/librpitx.a -lm -lsndfile -lrt -lpthread -L/opt/vc/lib -lbcm_host
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../pifmrds pifmrds/rds.o pifmrds/waveforms.o pifmrds/pi_fm_rds.cpp pifmrds/fm_mpx.o pifmrds/control_pipe.o -lm -lsndfile -lrt -lpthread -L/opt/vc/lib -lrpitx
 
-../rpitx: rpitxv1/rpitx.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -Wno-write-strings -o ../rpitx rpitxv1/rpitx.cpp $(LDFLAGS)
+../rpitx: rpitxv1/rpitx.cpp 
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../rpitx rpitxv1/rpitx.cpp $(LDFLAGS)
 
-../corel8: corel8/corel8.cpp corel8/costas8.h librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -Wno-write-strings -o ../corel8 corel8/corel8.cpp $(LDFLAGS)
+../corel8: corel8/corel8.cpp corel8/costas8.h 
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../corel8 corel8/corel8.cpp $(LDFLAGS)
 
-../pift8 : pift8/pift8.cpp pift8/ft8_lib/ft8/constants.cpp pift8/ft8_lib/ft8/text.cpp pift8/ft8_lib/ft8/pack.cpp pift8/ft8_lib/ft8/encode.cpp librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -Wno-write-strings -o ../pift8 pift8/pift8.cpp pift8/ft8_lib/ft8/constants.cpp pift8/ft8_lib/ft8/text.cpp pift8/ft8_lib/ft8/pack.cpp pift8/ft8_lib/ft8/encode.cpp  $(LDFLAGS)
+../pift8 : pift8/pift8.cpp  
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../pift8 pift8/pift8.cpp -lft8 $(LDFLAGS) 
 
-../sendook: ook/sendook.cpp ook/optparse.c librpitx/src/librpitx.a
-	$(CCP) $(CXXFLAGS) -Wno-write-strings -o ../sendook ook/sendook.cpp ook/optparse.c $(LDFLAGS)
+../sendook: ook/sendook.cpp ook/optparse.c 
+	$(CXX) $(CXXFLAGS) -Wno-write-strings -o ../sendook ook/sendook.cpp ook/optparse.c $(LDFLAGS)
 
 CFLAGS_Pifm	= -Wall -g -O2 -Wno-unused-variable
-LDFLAGS_Pifm	= librpitx/src/librpitx.a -lm -lrt -lpthread -lsndfile -L/opt/vc/lib -lbcm_host
+LDFLAGS_Pifm	= $(LDFLAGS) -lsndfile
 ../pifm : ../fm/pifm.c
 	$(CC) $(CFLAGS_Pifm) -o ../pifm ../fm/pifm.c  $(LDFLAGS_Pifm)
 
 CFLAGS_Piam	= -Wall -g -O2 -Wno-unused-variable
-LDFLAGS_Piam	= librpitx/src/librpitx.a -lm -lrt -lpthread -lsndfile -L/opt/vc/lib -lbcm_host
+LDFLAGS_Piam	= $(LDFLAGS_Pifm)
 ../piam : ../am/piam.c
 	$(CC) $(CFLAGS_Piam) -o ../piam ../am/piam.c  $(LDFLAGS_Piam)
 
 CFLAGS_Pidcf77	= -Wall -g -O2 -Wno-unused-variable
-LDFLAGS_Pidcf77	= librpitx/src/librpitx.a -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
 ../pidcf77 : ../dcf77/pidcf77.c
-	$(CC) $(CFLAGS_Piam) -o ../pidcf77 ../dcf77/pidcf77.c  $(LDFLAGS_Piam)
+	$(CC) $(CFLAGS_Piam) -o ../pidcf77 ../dcf77/pidcf77.c  $(LDFLAGS)
 clean:
 	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook
 

--- a/src/chirp/chirp.cpp
+++ b/src/chirp/chirp.cpp
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 #include <unistd.h>
 #include "stdio.h"
 #include <cstring>

--- a/src/corel8/corel8.cpp
+++ b/src/corel8/corel8.cpp
@@ -14,7 +14,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 #include "costas8.h"
 
 float frequency=14.07e6;

--- a/src/dvb/dvbrf.cpp
+++ b/src/dvb/dvbrf.cpp
@@ -1,6 +1,6 @@
 #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
-#include "stdio.h"
+#include <librpitx/librpitx.h>
+#include <stdio.h>
 #include <cstring>
 #include <signal.h>
 #include <stdlib.h>

--- a/src/foxhunt/foxhunt.cpp
+++ b/src/foxhunt/foxhunt.cpp
@@ -1,113 +1,87 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <cstring>
 #include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <stdint.h>
-#include <math.h>
-#include <time.h>
-#include <signal.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/mman.h>
-
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
 
 #include <librpitx/librpitx.h>
-
 
 int FileFreqTiming;
 
 ngfmdmasync *fmmod;
-static double GlobalTuningFrequency=00000.0;
-int FifoSize=10000; //10ms
-double frequencyshift=20000;
-bool running=true;
+static double GlobalTuningFrequency = 00000.0;
+int FifoSize = 10000; // 10ms
+double frequencyshift = 20000;
+bool running = true;
 
-void playtone(double Frequency,uint32_t Timing)//Timing in 0.1us
+void playtone(double Frequency, uint32_t Timing) // Timing in 0.1us
 {
-                uint32_t SumTiming=0;
-                SumTiming+=Timing%100;
-                if(SumTiming>=100)
-                {
-                        Timing+=100;
-                        SumTiming=SumTiming-100;
-                }
-                int NbSamples=(Timing/100);
+  uint32_t SumTiming = 0;
+  SumTiming += Timing % 100;
+  if (SumTiming >= 100) {
+    Timing += 100;
+    SumTiming = SumTiming - 100;
+  }
+  int NbSamples = (Timing / 100);
 
-                while(NbSamples>0)
-                {
-                        usleep(10);
-                        int Available=fmmod->GetBufferAvailable();
-                        if(Available>FifoSize/2)
-                        {
-                                int Index=fmmod->GetUserMemIndex();
-                                if(Available>NbSamples) Available=NbSamples;
-                                for(int j=0;j<Available;j++)
-                                {
-                                        fmmod->SetFrequencySample(Index+j,Frequency);
-                                        NbSamples--;
-
-                                }
-                        }
-                }
-}
-
-
-
-
-
-static void SendTones()
-{
-double basefreq = 1100;
-double freq2 = 1100 + frequencyshift;
-while(running)
-{
-        playtone( 1100 , 10000000) ;
-        playtone( freq2 , 10000000) ;
-}
-}
-
-static void
-terminate(int num)
-{
-    running=false;
-        fprintf(stderr,"Caught signal - Terminating %x\n",num);
-
-}
-
-int main(int argc, char **argv)
-{
-        float frequency=144.5e6;
-        if (argc > 1)
-        {
-
-
-                 frequency=atof(argv[1]);
-                 frequencyshift=atof(argv[2]);
-
-        }
-        else
-        {
-                printf("usage : foxhunt frequency(Hz) frequency shift(Hz)\n");
-                exit(0);
-        }
-
-        for (int i = 0; i < 64; i++) {
-        struct sigaction sa;
-
-        std::memset(&sa, 0, sizeof(sa));
-        sa.sa_handler = terminate;
-        sigaction(i, &sa, NULL);
+  while (NbSamples > 0) {
+    usleep(10);
+    int Available = fmmod->GetBufferAvailable();
+    if (Available > FifoSize / 2) {
+      int Index = fmmod->GetUserMemIndex();
+      if (Available > NbSamples)
+        Available = NbSamples;
+      for (int j = 0; j < Available; j++) {
+        fmmod->SetFrequencySample(Index + j, Frequency);
+        NbSamples--;
+      }
     }
-
-        fmmod=new ngfmdmasync(frequency,100000,14,FifoSize);
-        SendTones();
-        delete fmmod;
-        return 0;
+  }
 }
 
+static void SendTones() {
+  double basefreq = 1100;
+  double freq2 = 1100 + frequencyshift;
+  while (running) {
+    playtone(1100, 10000000);
+    playtone(freq2, 10000000);
+  }
+}
 
+static void terminate(int num) {
+  running = false;
+  fprintf(stderr, "Caught signal - Terminating %x\n", num);
+}
 
+int main(int argc, char **argv) {
+  float frequency = 144.5e6;
+  if (argc > 1) {
+    frequency = atof(argv[1]);
+    frequencyshift = atof(argv[2]);
+  } else {
+    printf("usage : foxhunt frequency(Hz) frequency shift(Hz)\n");
+    exit(0);
+  }
 
+  for (int i = 0; i < 64; i++) {
+    struct sigaction sa;
+
+    std::memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = terminate;
+    sigaction(i, &sa, NULL);
+  }
+
+  fmmod = new ngfmdmasync(frequency, 100000, 14, FifoSize);
+  SendTones();
+  delete fmmod;
+  return 0;
+}

--- a/src/foxhunt/foxhunt.cpp
+++ b/src/foxhunt/foxhunt.cpp
@@ -14,7 +14,7 @@
 #include <sys/mman.h>
 
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 
 int FileFreqTiming;

--- a/src/freedv/freedv.cpp
+++ b/src/freedv/freedv.cpp
@@ -14,7 +14,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 int FileVCO;
 bool running=true;

--- a/src/fsq/pifsq.cpp
+++ b/src/fsq/pifsq.cpp
@@ -40,7 +40,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 #define TONE_SPACING            8789           // ~8.7890625 Hz
 #define BAUD_2                  7812          // CTC value for 2 baud

--- a/src/morse/morse.cpp
+++ b/src/morse/morse.cpp
@@ -13,7 +13,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <ctype.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 #define MORSECODES 37
 

--- a/src/ook/sendook.cpp
+++ b/src/ook/sendook.cpp
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 #include "optparse.h"
 #include <unistd.h>
 #include "stdio.h"

--- a/src/opera/opera.cpp
+++ b/src/opera/opera.cpp
@@ -37,7 +37,7 @@
 #include "math.h"
 #include <signal.h>
  #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 bool running=true;
 //#define  __VCpp__  TRUE
 

--- a/src/pifmrds/pi_fm_rds.cpp
+++ b/src/pifmrds/pi_fm_rds.cpp
@@ -112,7 +112,7 @@ extern "C"
 #include "control_pipe.h"
 }
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 ngfmdmasync *fmmod;
 // The deviation specifies how wide the signal is. 

--- a/src/pift8/Makefile
+++ b/src/pift8/Makefile
@@ -1,17 +1,17 @@
-CXXFLAGS = -std=c++14 -I.
+CXXFLAGS ?= -std=c++14 -I.
 LDFLAGS = -lm
 
-gen_ft8: gen_ft8.o ft8/encode.o ft8/pack.o ft8/text.o ft8/pack_77.o ft8/encode_91.o common/wave.o
-	$(CXX) $(LDFLAGS) -o $@ $^
+gen_ft8: gen_ft8.o common/wave.o
+	$(CXX) $(LDFLAGS) -o $@ $^ -lpift8
 
-pift8: pift8.o ft8/encode.o ft8/pack.o ft8/text.o ft8/pack_77.o ft8/encode_91.o common/wave.o ../librpitx/src/librpitx.a
-	$(CXX) $(LDFLAGS) -o $@ $^
+pift8: pift8.o common/wave.o
+	$(CXX) $(LDFLAGS) -o $@ $^ -lrpitx -lpift8
 
 .PHONY: run_tests
 
 run_tests: test
 	@./test
 
-test:  test.o ft8/encode.o ft8/pack.o ft8/text.o ft8/pack_77.o ft8/encode_91.o ft8/unpack.o
-	$(CXX) $(LDFLAGS) -o $@ $^
+test:  test.o
+	$(CXX) $(LDFLAGS) -o $@ $^ -lft8
 

--- a/src/pift8/pift8.cpp
+++ b/src/pift8/pift8.cpp
@@ -5,12 +5,12 @@
 #include <signal.h>
 #include <unistd.h>
 
-#include "ft8_lib/common/wave.h"
-#include "ft8_lib/ft8/pack.h"
-#include "ft8_lib/ft8/encode.h"
-#include "ft8_lib/ft8/constants.h"
+#include "ft8/wave.h"
+#include "ft8/pack.h"
+#include "ft8/encode.h"
+#include "ft8/constants.h"
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 bool running=true;
 

--- a/src/pirtty/pirtty.cpp
+++ b/src/pirtty/pirtty.cpp
@@ -12,19 +12,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>
-
-
-
-
-#include "../librpitx/src/librpitx.h"
-
-
-
-
-
+#include <librpitx/librpitx.h>
 
 #define byte uint8_t
-
 
 int MARK = 2125;
 int SPACE = 1955;

--- a/src/pocsag/pocsag.cpp
+++ b/src/pocsag/pocsag.cpp
@@ -33,7 +33,7 @@ Fork and modification for rpitx (c)(F5OEO 2018)
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 #define PROGRAM_VERSION "0.3"
 //Check out main() at the bottom of the file

--- a/src/rpitxv1/rpitx.cpp
+++ b/src/rpitxv1/rpitx.cpp
@@ -20,8 +20,8 @@
    Helped by a code fragment by PE1NNZ (http://pe1nnz.nl.eu.org/2013/05/direct-ssb-generation-on-pll.html)
  */
 #include <unistd.h>
-#include "../librpitx/src/librpitx.h"
-#include "stdio.h"
+#include <librpitx/librpitx.h>
+#include <stdio.h>
 #include <stdarg.h>     /* va_list, va_start, va_arg, va_end */
 #include <cstring>
 #include <signal.h>

--- a/src/sendiq.cpp
+++ b/src/sendiq.cpp
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include "librpitx/src/librpitx.h"
+#include "librpitx.h"
 #include "stdio.h"
 #include <cstring>
 #include <signal.h>

--- a/src/spectrumpaint/spectrum.cpp
+++ b/src/spectrumpaint/spectrum.cpp
@@ -14,7 +14,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 int FilePicture;
 int FileFreqTiming;

--- a/src/sstv/pisstv.cpp
+++ b/src/sstv/pisstv.cpp
@@ -15,7 +15,7 @@
 #include <sys/mman.h>
 
 
-#include "../librpitx/src/librpitx.h"
+#include <librpitx/librpitx.h>
 
 int FilePicture;
 int FileFreqTiming;

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -1,5 +1,5 @@
 #include <unistd.h>
-#include "librpitx/src/librpitx.h"
+#include "librpitx.h"
 #include "stdio.h"
 #include <cstring>
 #include <signal.h>


### PR DESCRIPTION
* Makefile: link to library rather than object files
* header files in /usr/local/include/librpitx which is in system path so only include <librpitx/librpitx.h>