### PR TITLE
Cleanup command line argument parsing & installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,6 +6,7 @@ LDFLAGS ?= -L/opt/vc/lib
 LDFLAGS += -lrpitx -lm -lrt -lpthread
 CXX ?= c++
 CC ?= cc
+INTSTALL_DIR ?= /usr/local/bin
 
 CFLAGS_Pissb	= -Wall -g -O2 -Wno-unused-variable
 LDFLAGS_Pissb	= $(LDFLAGS) -lsndfile -lliquid
@@ -94,15 +95,15 @@ clean:
 	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook
 
 install: all
-	install -m 0755 ../pisstv /usr/bin
-	install -m 0755 ../foxhunt /usr/bin
-	install -m 0755 ../pirtty /usr/bin
-	install -m 0755 ../piopera /usr/bin
-	install -m 0755 ../pifsq /usr/bin
-	install -m 0755 ../pichirp /usr/bin
-	install -m 0755 ../sendiq /usr/bin
-	install -m 0755 ../tune /usr/bin
-	install -m 0755 ../freedv /usr/bin
-	install -m 0755 ../rpitx /usr/bin
-	install -m 0755 ../pift8 /usr/bin
-	install -m 0755 ../sendook /usr/bin
+	install -m 0755 ../pisstv $(INSTALL_DIR)
+	install -m 0755 ../foxhunt $(INSTALL_DIR)
+	install -m 0755 ../pirtty $(INSTALL_DIR)
+	install -m 0755 ../piopera $(INSTALL_DIR)
+	install -m 0755 ../pifsq $(INSTALL_DIR)
+	install -m 0755 ../pichirp $(INSTALL_DIR)
+	install -m 0755 ../sendiq $(INSTALL_DIR)
+	install -m 0755 ../tune $(INSTALL_DIR)
+	install -m 0755 ../freedv $(INSTALL_DIR)
+	install -m 0755 ../rpitx $(INSTALL_DIR)
+	install -m 0755 ../pift8 $(INSTALL_DIR)
+	install -m 0755 ../sendook $(INSTALL_DIR)

--- a/src/rpitxv1/rpitx.cpp
+++ b/src/rpitxv1/rpitx.cpp
@@ -48,7 +48,9 @@ Usage:\nrpitx [-i File Input][-m ModeInput] [-f frequency output] [-s Samplerate
 -f float      frequency to output on GPIO_4 pin 7 in khz : (130 kHz to 750 MHz),\n\
 -l            loop mode for file input\n\
 -p float      frequency correction in parts per million (ppm), positive or negative, for calibration, default 0.\n\
+-q            Use harmonic number n\n\
 -h            help (this help).\n\
+-s            SampleRate input file sample rate (only in IEQ mode) \n\
 \n",\
 PROGRAM_VERSION);
 
@@ -87,6 +89,7 @@ int main(int argc, char* argv[])
     bool loop_mode_flag=false;
     bool useStdin;
     int Harmonic=1;
+  char * endptr;
 	while(1)
 	{
 		a = getopt(argc, argv, "i:f:m:s:p:hld:w:c:ra:");
@@ -104,7 +107,11 @@ int main(int argc, char* argv[])
 			FileName = optarg;
 			break;
 		case 'f': // Frequency
-			SetFrequency = atof(optarg)*1e3;
+      SetFrequency = strtof(optarg, &endptr);
+      if (endptr == optarg || SetFrequency <= 0.0f || SetFrequency == HUGE_VALF) {
+        fprintf(stderr, "tune: not a valid frequency - '%s'", optarg)
+        exit(1);
+      }
 			break;
 		case 'm': // Mode (IQ,IQFLOAT,RF,RFA)
 			if(strcmp("IQ",optarg)==0) Mode=MODE_RPITX_IQ;
@@ -117,8 +124,11 @@ int main(int argc, char* argv[])
 			SampleRate = atoi(optarg);
 			break;
 		case 'p':  //	ppmcorrection
-			ppmpll = atof(optarg);
-			
+      ppmpll = strtof(optarg, &endptr);
+      if (endptr == optarg || ppmpll  <= 0.0f || ppmpll  == HUGE_VALF) {
+        fprintf(stderr, "tune: not a valid ppm - '%s'", optarg)
+        exit(1);
+      }		
 			break;
 		case 'h': // help
 			print_usage();
@@ -136,14 +146,18 @@ int main(int argc, char* argv[])
 				fprintf(stderr,"Warning : 'w' parameter not used in this version\n");
 			break;
 		case 'r': // Randomize PWM frequency 
-				fprintf(stderr,"Warning : 'r' parameter not used in this version\n");
-			
+				fprintf(stderr,"Warning : 'r' parameter not used in this version\n");			
 			break;
 		case 'a': // DMA Channel 1-14
 			 	fprintf(stderr,"Warning : 'a' parameter not used in this version\n");
+		case 'q': // Harmonic number
+			Harmonic=atoi(optarg);
+      break;
+
 			break;
         	case -1:
         	break;
+
 		case '?':
 			if (isprint(optopt) )
  			{

--- a/src/sendiq.cpp
+++ b/src/sendiq.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
 	enum {typeiq_i16,typeiq_u8,typeiq_float,typeiq_double};
 	int InputType=typeiq_i16;
 	int Decimation=1;
-        
+  char * endptr = NULL;
 	while(1)
 	{
 		a = getopt(argc, argv, "i:f:s:m:p:h:ldt:");
@@ -127,11 +127,15 @@ int main(int argc, char* argv[])
 			if (drivedds>7.0) {drivedds=7.0;}
 			break;
 		case 'f': // Frequency
-			SetFrequency = atof(optarg);
-			break;
-                case 'm': // Shared memory token
-                        sharedmem_token = atoi(optarg);
-     	                InputType=typeiq_float;      //if using shared memory force float pipe
+      SetFrequency = strtof(optarg, &endptr);
+      if (endptr == optarg || SetFrequency <= 0.0f || SetFrequency == HUGE_VALF) {
+        fprintf(stderr, "tune: not a valid frequency - '%s'", optarg)
+        exit(1);
+      }
+			break;			
+    case 'm': // Shared memory token
+      sharedmem_token = atoi(optarg);
+     	InputType=typeiq_float;      //if using shared memory force float pipe
 			break;
 		case 's': // SampleRate (Only needeed in IQ mode)
 			SampleRate = atoi(optarg);
@@ -157,7 +161,7 @@ int main(int argc, char* argv[])
 				}
 			};
 			break;
-		case 'h': // help
+		case 'h': // Harmonic numebr
 			Harmonic=atoi(optarg);
 			break;
 		case 'l': // loop mode

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -37,10 +37,12 @@ int main(int argc, char* argv[])
 {
 	int a;
 	int anyargs = 0;
-	float SetFrequency=434e6;
+	float SetFrequency = 434e6;
 	dbg_setlevel(1);
 	bool NotKill=false;
-	float ppm=1000.0;
+  bool ppmSet = false;
+	float ppm = 0.0f;
+  char * endptr = NULL;
 	while(1)
 	{
 		a = getopt(argc, argv, "f:ehp:");
@@ -55,13 +57,22 @@ int main(int argc, char* argv[])
 		switch(a)
 		{
 		case 'f': // Frequency
-			SetFrequency = atof(optarg);
+      SetFrequency = strtof(optarg, &endptr);
+      if (endptr == optarg || SetFrequency <= 0.0f || SetFrequency == HUGE_VALF) {
+        fprintf(stderr, "tune: not a valid frequency - '%s'", optarg)
+        exit(1);
+      }
 			break;
 		case 'e': //End immediately
 			NotKill=true;
 			break;
 		case 'p': //ppm
-			ppm=atof(optarg);
+      ppm = strtof(optarg, &endptr);
+      if (endptr == optarg || ppm <= 0.0f || ppm == HUGE_VALF) {
+        fprintf(stderr, "tune: not a valid ppm - '%s'", optarg)
+        exit(1);
+      }
+      ppmSet = true;
 			break;	
 		case 'h': // help
 			print_usage();
@@ -105,7 +116,7 @@ int main(int argc, char* argv[])
 		pad.setlevel(7);
 		clkgpio *clk=new clkgpio;
 		clk->SetAdvancedPllMode(true);
-		if(ppm!=1000)	//ppm is set else use ntp
+		if(ppmSet)	//ppm is set else use ntp
 			clk->Setppm(ppm);
 		clk->SetCenterFrequency(SetFrequency,10);
 		clk->SetFrequency(000);


### PR DESCRIPTION
I had some issues with the program crashing and other problems. I made a number of changes here to address those:

1. Install to `/usr/local/bin`.  For programs not from the package manager on a linux machine this is the normal location.
2. Avoid use of `atof` for parsing command line arguments. Use `strtof` instead. Check this result and if it isn't valid just terminate the program with an error. This prevents crashing the raspberry pi when an incorrect command line argument like 'bananas` is passed for the frequency arguments
3. Normalize arguments between the two programs
4. Use a boolean flag to check if `ppm` has been set. Otherwise use ntp to try and determine the correct ppm
