### PR TITLE
Added fix for Raspbian 12 and minor edits to the Makefile for clean and install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,13 @@ read -r CONT
 if [ "$CONT" = "y" ]; then
   echo "Set GPU to 250Mhz in order to be stable"
    LINE='gpu_freq=250'
+   if [ ! -f /boot/firmware/config.txt ]; then
+   echo "Raspbian 11 or below detected using /boot/config.txt"
    FILE='/boot/config.txt'
+   else
+   echo "Raspbian 12 detected using /boot/firmware/config.txt"
+   FILE='/boot/firmware/config.txt'
+   fi
    grep -qF "$LINE" "$FILE"  || echo "$LINE" | sudo tee --append "$FILE"
    #PI4
    LINE='force_turbo=1'

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ CFLAGS_Pidcf77	= -Wall -g -O2 -Wno-unused-variable
 ../pidcf77 : ../dcf77/pidcf77.c
 	$(CC) $(CFLAGS_Piam) -o ../pidcf77 ../dcf77/pidcf77.c  $(LDFLAGS)
 clean:
-	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook ../foxhunt ../morse ../pift8 ../morse
+	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook ../foxhunt ../morse ../pift8
 
 install: all
 	install -m 0755 ../pisstv $(INSTALL_DIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ CFLAGS_Pidcf77	= -Wall -g -O2 -Wno-unused-variable
 ../pidcf77 : ../dcf77/pidcf77.c
 	$(CC) $(CFLAGS_Piam) -o ../pidcf77 ../dcf77/pidcf77.c  $(LDFLAGS)
 clean:
-	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook
+	rm -f  ../dvbrf ../sendiq ../pissb ../pisstv ../pifsq ../pifm ../piam ../pidcf77 ../pichirp ../tune ../freedv ../piopera ../spectrumpaint ../pocsag ../pifmrds ../rpitx ../sendook ../foxhunt ../morse ../pift8 ../morse
 
 install: all
 	install -m 0755 ../pisstv $(INSTALL_DIR)
@@ -109,3 +109,9 @@ install: all
 	install -m 0755 ../sendook $(INSTALL_DIR)
 	install -m 0755 ../dvbrf $(INSTALL_DIR)
 	install -m 0755 ../pifmrds $(INSTALL_DIR)
+	install -m 0755 ../pocsag $(INSTALL_DIR)
+	install -m 0755 ../pissb $(INSTALL_DIR)
+	install -m 0755 ../piam $(INSTALL_DIR)
+	install -m 0755 ../pidcf77 $(INSTALL_DIR)
+	install -m 0755 ../spectrumpaint $(INSTALL_DIR)
+	install -m 0755 ../morse $(INSTALL_DIR)


### PR DESCRIPTION
Added a simple fix to detect if the pi is running on Raspbian 12 or Raspbian 11 and below to install.sh.

Note from the raspberry pi website:
Prior to Bookworm, Raspberry Pi OS stored the boot partition at /boot/. Since Bookworm, the boot partition is located at /boot/firmware/.

Reference URL:
https://www.raspberrypi.com/documentation/computers/config_txt.html

I have also added just a few lines to the clean and the install functions of the Makefile.

Note that if the config lines are added to /boot/config.txt on Raspbian 12 they will be ignored at boot by the pi running Raspbian 12 I discovered this on my Pi Zero W V 1.1 after a fresh install and reboot rpitx kept crashing once I applied 

gpu_freq=250
force_turbo=1

to /boot/firmware/config.txt and rebooted the issue was resolved and rpitx was running perfectly fine.